### PR TITLE
Fix undefined slug field value

### DIFF
--- a/lib/mongoose-slug-hero.js
+++ b/lib/mongoose-slug-hero.js
@@ -58,7 +58,7 @@ function SlugHero (schema, options) {
 
     // --------- not options --------- //
 
-    // slug fields to be added to the schema 
+    // slug fields to be added to the schema
     slugAttrs = {}
 
   // Prepare the Counters to use
@@ -126,10 +126,13 @@ function SlugHero (schema, options) {
 
     for (var i = 0; i < scope.length; i++) {
       var k = scope[i]
-      _.set(newVal, k, _.get(updates, k))
+      var data = _.get(updates, k);
+      if (data) {
+        _.set(newVal, k, data);
+      }
     }
 
-    if (newVal) {
+    if (!_.isEmpty(newVal)) {
       _this.findOne({}, function (err, old) {
 
         if (!hasChanged(newVal, old)) {
@@ -187,7 +190,7 @@ function SlugHero (schema, options) {
           done()
 
         } else {
-          // Changed, add old slug value to the slugs as a history          
+          // Changed, add old slug value to the slugs as a history
           buildSlug(_this, true, done)
         }
       })
@@ -200,7 +203,7 @@ function SlugHero (schema, options) {
   function hasChanged (newData, oldData) {
     var changed = false
     for (var i = 0; i < scope.length; i++) {
-			var k = scope[i], newVal = _.get(newData, k), oldVal = _.get(oldData, k)			
+			var k = scope[i], newVal = _.get(newData, k), oldVal = _.get(oldData, k)
       if (!_.isEqual(newVal, oldVal)) {
         changed = true
         break
@@ -221,7 +224,7 @@ function SlugHero (schema, options) {
       _.get(data, slugsFieldName).push(_.get(data, slugFieldName))
     }
 
-    // Get next counter within scope	
+    // Get next counter within scope
     Counters.findByIdAndUpdate(opt.key, { $inc: { seq: 1 } }, { upsert: true, new: true }, function (err, res) {
       if (err) throw err
 


### PR DESCRIPTION
There were an issue on findOneAndUpdate hook, when the update data doesn't have any slug generating field, undefined is added to the newVal which seems like a change on hasChanged method so undefined was treated as a change which cause a break undefined.toString() while creating slug()