### PR TITLE
Improved build options method

### DIFF
--- a/lib/mongoose-slug-hero.js
+++ b/lib/mongoose-slug-hero.js
@@ -124,7 +124,8 @@ function SlugHero(schema, options) {
     // Build scope key
     for (var i = 0; i < scope.length; i++) {
       var k = scope[i]
-      key += k + '*' + (_.get(data, k) || '?') + '*'
+      var kSlug = slug(_.get(data, k), slugOptions);
+      key += k + '*' + (kSlug || '?') + '*';
     }
 
     return {


### PR DESCRIPTION
Supposed I have this config.  ProductSchema.plugin(slugHero, {doc: 'products', field: 'name'}); and two products with same name and different capitalization.  For example Productone and productOne. In the counter collection you store the original value and for mongoDB Productone and productOne are different values.  If you slugify it, they will result in same slug and cause problems. 

My suggestion:
Store the slugified value in the counter collection.